### PR TITLE
Add sound effects for births and deaths

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,13 @@ export default function Page() {
   const [current, setCurrent] = useState<number>(START);
   const [running, setRunning] = useState<boolean>(true);
 
+  const playSound = (src: string, count: number) => {
+    for (let i = 0; i < count; i++) {
+      const audio = new Audio(src);
+      setTimeout(() => audio.play(), i * 200);
+    }
+  };
+
   useEffect(() => {
     if (running) {
       const timer = setInterval(() => {
@@ -21,6 +28,13 @@ export default function Page() {
       return () => clearInterval(timer);
     }
   }, [running, start, end]);
+
+  useEffect(() => {
+    const births = presidents.filter(p => p.birth === current).length;
+    const deaths = presidents.filter(p => p.death === current).length;
+    if (births) playSound('/pop-cartoon-328167.mp3', births);
+    if (deaths) playSound('/bell-323942.mp3', deaths);
+  }, [current, presidents]);
 
   const generatePresidents = async () => {
     try {


### PR DESCRIPTION
## Summary
- Play pop sound for each birth and bell for each death as timeline years advance
- Repeat sounds sequentially to match multiple births or deaths in a year

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a96128560883269b1fdf8c8b669d2b