### PR TITLE
Use president images as card backgrounds

### DIFF
--- a/components/PresidentCard.tsx
+++ b/components/PresidentCard.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { President, TimelineEvent } from '../data/presidents';
+
+interface PresidentCardProps {
+  pres: President;
+  visible: boolean;
+  className: string;
+  current: number;
+  partyColour: string;
+  currentEvent?: TimelineEvent;
+}
+
+export default function PresidentCard({ pres, visible, className, current, partyColour, currentEvent }: PresidentCardProps) {
+  const [bgUrl, setBgUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const bases = ['', '/images', '/presidents'];
+    const exts = ['jpg', 'jpeg', 'png', 'webp'];
+    (async () => {
+      for (const base of bases) {
+        for (const ext of exts) {
+          const url = `${base}/${encodeURIComponent(pres.name)}.${ext}`;
+          try {
+            const res = await fetch(url, { method: 'HEAD' });
+            if (res.ok) {
+              if (!cancelled) setBgUrl(url);
+              return;
+            }
+          } catch {
+            // Ignore errors and try next extension
+          }
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [pres.name]);
+
+  const style = bgUrl
+    ? {
+        backgroundImage: `linear-gradient(rgba(0,0,0,0.5), rgba(0,0,0,0.5)), url(${bgUrl})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+        backgroundRepeat: 'no-repeat',
+      }
+    : undefined;
+
+  return (
+    <div className={className} style={style}>
+      {visible && (
+        <>
+          <div className="name">{pres.name}</div>
+          <div className="lifespan">
+            {pres.birth} – {pres.death ?? 'present'} ()
+          </div>
+          <div className="party" style={{ backgroundColor: partyColour }}>
+            {pres.party}
+          </div>
+          <div className="age">
+            {Math.min(current, pres.death ?? current) - pres.birth}yo
+          </div>
+          {currentEvent && <div className="event">{currentEvent.text}</div>}
+        </>
+      )}
+    </div>
+  );
+}
+

--- a/components/TimelineGrid.tsx
+++ b/components/TimelineGrid.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { isPresident, President } from '../data/presidents';
+import PresidentCard from './PresidentCard';
 
 const PARTY_COLOURS: Record<string, string> = {
   whig: '#95bde9ff',
@@ -34,23 +37,15 @@ export default function TimelineGrid({ current, presidents }: TimelineGridProps)
           : 'cell';
         const partyColour = PARTY_COLOURS[pres.party.toLowerCase()] || '#999';
         return (
-          <div className={className} key={idx}>
-            {visible && (
-              <>
-                <div className="name">{pres.name}</div>
-                <div className="lifespan">
-                  {pres.birth} – {pres.death ?? 'present'} ()
-                </div>
-                <div className="party" style={{ backgroundColor: partyColour }}>
-                  {pres.party}
-                </div>
-                <div className="age">
-                  {Math.min(current, pres.death ?? current) - pres.birth}yo
-                </div>
-                {currentEvent && <div className="event">{currentEvent.text}</div>}
-              </>
-            )}
-          </div>
+          <PresidentCard
+            key={idx}
+            pres={pres}
+            visible={visible}
+            className={className}
+            current={current}
+            partyColour={partyColour}
+            currentEvent={currentEvent}
+          />
         );
       })}
     </div>


### PR DESCRIPTION
## Summary
- Check for president-specific images (jpg, jpeg, png, webp) and use them as card backgrounds when found
- Add dark gradient overlay to keep card text legible over background images
- Refactor timeline grid to use new PresidentCard component for image detection and rendering

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aaa95943208326b37ed544642c8909