### PR TITLE
Scale layout for small screens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,10 +2,7 @@ body {
   margin: 0;
   font-family: Arial, sans-serif;
   background: linear-gradient(135deg, #667eea, #764ba2);
-  height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  min-height: 100vh;
   color: white;
 }
 
@@ -14,11 +11,11 @@ body {
   background: rgba(255,255,255,0.1);
   backdrop-filter: blur(10px);
   border-radius: 20px;
-  padding: 30px;
+  padding: 30px 10px;
   box-shadow: 0 20px 40px rgba(0,0,0,0.3);
   width: 100%;
   box-sizing: border-box;
-  transform-origin: top center;
+  transform-origin: top left;
 }
 
 .grid {
@@ -27,7 +24,7 @@ body {
   grid-auto-rows: 160px;
   gap: 10px;
   margin-bottom: 20px;
-  width: 95%;
+  width: 100%;
 }
 
 .cell {

--- a/app/globals.css
+++ b/app/globals.css
@@ -17,6 +17,8 @@ body {
   padding: 30px;
   box-shadow: 0 20px 40px rgba(0,0,0,0.3);
   width: 100%;
+  box-sizing: border-box;
+  transform-origin: top center;
 }
 
 .grid {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import TimelineGrid from '../components/TimelineGrid';
 import ProgressBar from '../components/ProgressBar';
 import MusicControls from '../components/MusicControls';
 import { START, END, PRESIDENTS, President } from '../data/presidents';
 
 export default function Page() {
+  const containerRef = useRef<HTMLDivElement>(null);
   const [presidents, setPresidents] = useState<President[]>(PRESIDENTS);
   const [start, setStart] = useState<number>(START);
   const [end, setEnd] = useState<number>(END);
@@ -38,6 +39,22 @@ export default function Page() {
     if (deaths) playSound('/bell.mp3', deaths);
   }, [current, presidents]);
 
+  useEffect(() => {
+    const resize = () => {
+      const el = containerRef.current;
+      if (!el) return;
+      const scale = Math.min(
+        window.innerWidth / el.scrollWidth,
+        window.innerHeight / el.scrollHeight,
+        1
+      );
+      el.style.transform = `scale(${scale})`;
+    };
+    resize();
+    window.addEventListener('resize', resize);
+    return () => window.removeEventListener('resize', resize);
+  }, []);
+
   const generatePresidents = async () => {
     try {
       const res = await fetch('/api/presidents', { method: 'POST' });
@@ -60,11 +77,18 @@ export default function Page() {
   };
 
   return (
-    <div className="container">
+    <div className="container" ref={containerRef}>
       <h2>Aerobea Presidential Timeline</h2>
       <TimelineGrid current={current} presidents={presidents} />
       <div className="year">{current}</div>
-      <ProgressBar current={current} setCurrent={setCurrent} running={running} setRunning={setRunning} start={start} end={end} />
+      <ProgressBar
+        current={current}
+        setCurrent={setCurrent}
+        running={running}
+        setRunning={setRunning}
+        start={start}
+        end={end}
+      />
       <div>
         <button onClick={() => setRunning(r => !r)}>{running ? 'Pause' : 'Play'}</button>
         <button onClick={() => setCurrent(start)}>Reset</button>


### PR DESCRIPTION
## Summary
- scale the container to fit within the viewport
- adjust container styling for border-box sizing and transform origin
- reformat ProgressBar props for readability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aad9b10504832686edcb913a6cd24c