### PR TITLE
Show current monarch in timeline

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -111,6 +111,11 @@ body {
   margin: 15px 0;
 }
 
+.monarch {
+  font-size: 1rem;
+  margin-bottom: 10px;
+}
+
 .progress-container {
   position: relative;
   width: 100%;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,14 @@ import { useState, useEffect, useRef } from 'react';
 import TimelineGrid from '../components/TimelineGrid';
 import ProgressBar from '../components/ProgressBar';
 import MusicControls from '../components/MusicControls';
-import { START, END, PRESIDENTS, President } from '../data/presidents';
+import {
+  START,
+  END,
+  PRESIDENTS,
+  President,
+  MONARCHS,
+  getMonarch,
+} from '../data/presidents';
 
 export default function Page() {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -13,6 +20,8 @@ export default function Page() {
   const [end, setEnd] = useState<number>(END);
   const [current, setCurrent] = useState<number>(START);
   const [running, setRunning] = useState<boolean>(true);
+
+  const currentMonarch = getMonarch(current, MONARCHS);
 
   const playSound = (src: string, count: number, volume = 1, offset = 0) => {
     for (let i = 0; i < count; i++) {
@@ -80,6 +89,16 @@ export default function Page() {
     <div className="container" ref={containerRef}>
       <h2>Aerobea Presidential Timeline</h2>
       <div className="year">{current}</div>
+      <div
+        className="monarch"
+        title={
+          currentMonarch?.death_cause
+            ? `Died of ${currentMonarch.death_cause}`
+            : undefined
+        }
+      >
+        Monarch: {currentMonarch ? currentMonarch.name : '—'}
+      </div>
       <ProgressBar
         current={current}
         setCurrent={setCurrent}

--- a/data/presidents.ts
+++ b/data/presidents.ts
@@ -33,6 +33,24 @@ export function isPresident(year: number, president: President): boolean {
   return false;
 }
 
+export interface Monarch {
+  name: string;
+  birth: number;
+  death: number | null;
+  start_reign: number;
+  end_reign: number | null;
+  death_cause: string | null;
+}
+
+export function getMonarch(
+  year: number,
+  monarchs: Monarch[]
+): Monarch | undefined {
+  return monarchs.find(
+    m => year >= m.start_reign && (m.end_reign === null || year <= m.end_reign)
+  );
+}
+
 
 export const PRESIDENTS : President[] = [
   {
@@ -440,7 +458,7 @@ export const PRESIDENTS : President[] = [
   }
 ];
 
-export const MONARCHS = [
+export const MONARCHS: Monarch[] = [
 
   {
     name: "benadict I",


### PR DESCRIPTION
## Summary
- define Monarch type and helper to determine reigning monarch
- display current monarch atop the timeline with cause-of-death tooltip
- add compact styling for monarch line

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aebbd189188326896fe3466fe4cc43