### PR TITLE
chore: add varied dates for presidents

### DIFF
--- a/data/presidents.ts
+++ b/data/presidents.ts
@@ -58,83 +58,83 @@ export const PRESIDENTS : President[] = [
   {
     name: "Baahram Edward Lincoln the Elder",
     party: "Whig",
-    birth: d(1674),
-    death: d(1735),
+    birth: d(1674, 8, 27),
+    death: d(1735, 5, 3),
     events: [
-      { date: d(1701), text: "Elected as first President of Aerobea" },
-      { date: d(1702), type: PRESIDENCY_BEGINS, text: "Sworn into office" },
-      { date: d(1722), type: PRESIDENCY_ENDS, text: "Resigned from office" },
-      { date: d(1735), type: DEATH, text: "Died of  blood cancer" }
+      { date: d(1701, 6, 25), text: "Elected as first President of Aerobea" },
+      { date: d(1702, 6, 4), type: PRESIDENCY_BEGINS, text: "Sworn into office" },
+      { date: d(1722, 10, 26), type: PRESIDENCY_ENDS, text: "Resigned from office" },
+      { date: d(1735, 3, 12), type: DEATH, text: "Died of  blood cancer" }
 
     ]
   },
   {
     name: "Robert Crumbleton",
     party: "Whig",
-    birth: d(1698),
-    death: d(1765),
+    birth: d(1698, 11, 15),
+    death: d(1765, 10, 6),
     events: [
-      { date: d(1722), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1727), type: PRESIDENCY_ENDS, text: "Lost re-election" },
-      { date: d(1765), type: DEATH, text: "Died of cerebral haemorrhage" }
+      { date: d(1722, 8, 7), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1727, 3, 13), type: PRESIDENCY_ENDS, text: "Lost re-election" },
+      { date: d(1765, 5, 24), type: DEATH, text: "Died of cerebral haemorrhage" }
     ]
   },
   {
     name: "Ferito Beoe",
     party: "Conservative",
-    birth: d(1672),
-    death: d(1731),
+    birth: d(1672, 5, 16),
+    death: d(1731, 7, 11),
     events: [
-      { date: d(1727), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1731), type: PRESIDENCY_ENDS, text: "assassinated" }
+      { date: d(1727, 8, 6), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1731, 7, 2), type: PRESIDENCY_ENDS, text: "assassinated" }
     ]
   },
   {
     name: "joh gumn nocks",
     party: "liberal democratic",
-    birth: d(1693),
-    death: d(1760),
+    birth: d(1693, 6, 11),
+    death: d(1760, 3, 28),
     events: [
-      { date: d(1731), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1745), type: PRESIDENCY_ENDS, text: "stepped down" },
-      { date: d(1760), type: DEATH, text: "Died of diabetes complications" }
+      { date: d(1731, 5, 23), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1745, 10, 24), type: PRESIDENCY_ENDS, text: "stepped down" },
+      { date: d(1760, 9, 2), type: DEATH, text: "Died of diabetes complications" }
     ]
   },  
   {
     name: "Valu Jezza",
     party: "Labour",
-    birth: d(1708),
-    death: d(1779),
+    birth: d(1708, 8, 1),
+    death: d(1779, 6, 10),
     events: [
-      { date: d(1745), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1761), type: PRESIDENCY_ENDS, text: "Resigned" },
-      { date: d(1779), type: DEATH, text: "Died of typhoid fever" }
+      { date: d(1745, 10, 28), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1761, 5, 28), type: PRESIDENCY_ENDS, text: "Resigned" },
+      { date: d(1779, 12, 23), type: DEATH, text: "Died of typhoid fever" }
     ]
   },
   {
     name: "Commander Nullglyph",
     party: "Whig",
-    birth: d(1717),
-    death: d(1797),
+    birth: d(1717, 12, 26),
+    death: d(1797, 8, 16),
     events: [
-      { date: d(1761), type: PRESIDENCY_BEGINS, text: "Assumed office" },
-      { date: d(1777), type: PRESIDENCY_ENDS, text: "Kicked out" },
-      { date: d(1777), type: PRESIDENCY_BEGINS, text: "Seized power back" },
-      { date: d(1779), type: PRESIDENCY_ENDS, text: "Resigned in favour of Conservative Party" },
-      { date: d(1785), type: PRESIDENCY_BEGINS, text: "Re-Elected" },
-      { date: d(1787), type: PRESIDENCY_ENDS, text: "Retired" },
-      { date: d(1797), type: DEATH, text: "Died of heart failure" }
+      { date: d(1761, 10, 26), type: PRESIDENCY_BEGINS, text: "Assumed office" },
+      { date: d(1777, 11, 18), type: PRESIDENCY_ENDS, text: "Kicked out" },
+      { date: d(1777, 9, 4), type: PRESIDENCY_BEGINS, text: "Seized power back" },
+      { date: d(1779, 10, 9), type: PRESIDENCY_ENDS, text: "Resigned in favour of Conservative Party" },
+      { date: d(1785, 8, 9), type: PRESIDENCY_BEGINS, text: "Re-Elected" },
+      { date: d(1787, 3, 23), type: PRESIDENCY_ENDS, text: "Retired" },
+      { date: d(1797, 5, 1), type: DEATH, text: "Died of heart failure" }
     ]
   },
   {
     name: "emory di marison",
     party: "radical",
-    birth: d(1720),
-    death: d(1778),
+    birth: d(1720, 11, 5),
+    death: d(1778, 2, 16),
     events: [
-      { date: d(1777), type: PRESIDENCY_BEGINS, text: "Seized power" },
-      { date: d(1777), type: PRESIDENCY_ENDS, text: "Kicked out" },
-      { date: d(1778), type: DEATH, text: "burnt at the steak" }
+      { date: d(1777, 4, 9), type: PRESIDENCY_BEGINS, text: "Seized power" },
+      { date: d(1777, 2, 23), type: PRESIDENCY_ENDS, text: "Kicked out" },
+      { date: d(1778, 2, 2), type: DEATH, text: "burnt at the steak" }
     ]
   },
 
@@ -142,106 +142,106 @@ export const PRESIDENTS : President[] = [
   {
     name: "benjamin jones",
     party: "conservative",
-    birth: d(1730),
-    death: d(1806),
+    birth: d(1730, 9, 7),
+    death: d(1806, 10, 8),
     events: [
-      { date: d(1779), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1785), type: PRESIDENCY_ENDS, text: "Stepped down" },
-      { date: d(1794), type: PRESIDENCY_BEGINS, text: "Re-elected" },
-      { date: d(1796), type: PRESIDENCY_ENDS, text: "Loses re-elections" },
-      { date: d(1806), type: DEATH, text: "Died of pneumonia" }  
+      { date: d(1779, 8, 11), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1785, 2, 8), type: PRESIDENCY_ENDS, text: "Stepped down" },
+      { date: d(1794, 8, 5), type: PRESIDENCY_BEGINS, text: "Re-elected" },
+      { date: d(1796, 12, 7), type: PRESIDENCY_ENDS, text: "Loses re-elections" },
+      { date: d(1806, 7, 19), type: DEATH, text: "Died of pneumonia" }  
     ]
   },
   {
     name: "Jammes Jaglianviac",
     party: "Conservative",
-    birth: d(1717),
-    death: d(1796),
+    birth: d(1717, 9, 3),
+    death: d(1796, 7, 27),
     events: [
-      { date: d(1787), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1794), type: PRESIDENCY_ENDS, text: "Resigned due to age" },
-      { date: d(1796), type: DEATH, text: "Died of blood clot" }
+      { date: d(1787, 11, 2), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1794, 2, 12), type: PRESIDENCY_ENDS, text: "Resigned due to age" },
+      { date: d(1796, 4, 18), type: DEATH, text: "Died of blood clot" }
     ]
   },
   {
     name: "Stanley Roberts",
     party: "Conservative",
-    birth: d(1752),
-    death: d(1827),
+    birth: d(1752, 9, 21),
+    death: d(1827, 8, 17),
     events: [
-      { date: d(1796), type: PRESIDENCY_BEGINS, text: "Appointed Acting President" },
-      { date: d(1808), type: PRESIDENCY_ENDS, text: "Kicked out" },
-      { date: d(1809), type: PRESIDENCY_BEGINS, text: "Seized power back" },
-      { date: d(1812), type: PRESIDENCY_ENDS, text: "Stepped down" },      
-      { date: d(1827), type: DEATH, text: "Died of tuberculosis" }
+      { date: d(1796, 10, 11), type: PRESIDENCY_BEGINS, text: "Appointed Acting President" },
+      { date: d(1808, 5, 28), type: PRESIDENCY_ENDS, text: "Kicked out" },
+      { date: d(1809, 6, 5), type: PRESIDENCY_BEGINS, text: "Seized power back" },
+      { date: d(1812, 5, 10), type: PRESIDENCY_ENDS, text: "Stepped down" },      
+      { date: d(1827, 12, 6), type: DEATH, text: "Died of tuberculosis" }
     ]
   },
   {
     name: "lucrene dapth",
     party: "radical",
-    birth: d(1770),
-    death: d(1811),
+    birth: d(1770, 4, 22),
+    death: d(1811, 10, 1),
     events: [
-      { date: d(1808), type: PRESIDENCY_BEGINS, text: "Seized power" },
-      { date: d(1809), type: PRESIDENCY_ENDS, text: "Kicked out" },
-      { date: d(1811), type: DEATH, text: "beheaded" }
+      { date: d(1808, 5, 6), type: PRESIDENCY_BEGINS, text: "Seized power" },
+      { date: d(1809, 3, 5), type: PRESIDENCY_ENDS, text: "Kicked out" },
+      { date: d(1811, 9, 1), type: DEATH, text: "beheaded" }
     ]
   },
 
   {
     name: "Jack Prawn",
     party: "Conservative", 
-    birth: d(1773),
-    death: d(1818),
+    birth: d(1773, 3, 13),
+    death: d(1818, 1, 8),
     events: [
-      { date: d(1812), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1818), type: PRESIDENCY_ENDS, text: "Poisoned" },
-      { date: d(1818), type: DEATH, text: "Died of poisoned pipe that stanley roberts forgot to clean" }
+      { date: d(1812, 11, 14), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1818, 7, 24), type: PRESIDENCY_ENDS, text: "Poisoned" },
+      { date: d(1818, 7, 25), type: DEATH, text: "Died of poisoned pipe that stanley roberts forgot to clean" }
     ]
   },  
 
   {
     name: "Barkley Thunderflap",
     party: "GSC",
-    birth: d(1766),
-    death: d(1830),
+    birth: d(1766, 10, 9),
+    death: d(1830, 12, 9),
     events: [
-      { date: d(1818), type: PRESIDENCY_BEGINS, text: "Appointed Acting President (GSC-aligned dog)" },
-      { date: d(1821), type: PRESIDENCY_ENDS, text: "Resigned" },
-      { date: d(1830), type: DEATH, text: "Died of hydration issues" },
+      { date: d(1818, 2, 13), type: PRESIDENCY_BEGINS, text: "Appointed Acting President (GSC-aligned dog)" },
+      { date: d(1821, 7, 21), type: PRESIDENCY_ENDS, text: "Resigned" },
+      { date: d(1830, 10, 20), type: DEATH, text: "Died of hydration issues" },
     ]
   },
   {
     name: "Feathery Quill",
     party: "feather first",
-    birth: d(1791),
-    death: d(1821),
+    birth: d(1791, 3, 26),
+    death: d(1821, 5, 23),
     events: [
-      { date: d(1820), type: PRESIDENCY_BEGINS, text: "served 6 symbolic days" },
-      { date: d(1821), type: PRESIDENCY_ENDS, text: "died crashing into a blimp while trying to fly", }
+      { date: d(1820, 6, 11), type: PRESIDENCY_BEGINS, text: "served 6 symbolic days" },
+      { date: d(1821, 1, 25), type: PRESIDENCY_ENDS, text: "died crashing into a blimp while trying to fly", }
     ]
   },
   {
     name: "Oreo Joshon Boeoer",
     party: "socialist",
-    birth: d(1780),
-    death: d(1870),
+    birth: d(1780, 10, 21),
+    death: d(1870, 8, 10),
     events: [
-      { date: d(1821), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1840), type: PRESIDENCY_ENDS, text: "Retired" },
-      { date: d(1870), type: DEATH, text: "Died of cerebrovascular disease" }
+      { date: d(1821, 9, 6), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1840, 3, 3), type: PRESIDENCY_ENDS, text: "Retired" },
+      { date: d(1870, 3, 7), type: DEATH, text: "Died of cerebrovascular disease" }
     ]
   },
 
   {
     name: "tergo fluffbeard",
     party: "GSC",
-    birth: d(1790),
-    death: d(1878),
+    birth: d(1790, 3, 26),
+    death: d(1878, 8, 6),
     events: [
-      { date: d(1840), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1842), type: PRESIDENCY_ENDS, text: "lost re election" },
-      { date: d(1878), type: DEATH, text: "halatosis" }
+      { date: d(1840, 1, 6), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1842, 5, 11), type: PRESIDENCY_ENDS, text: "lost re election" },
+      { date: d(1878, 9, 12), type: DEATH, text: "halatosis" }
     ]
   },
 
@@ -249,81 +249,81 @@ export const PRESIDENTS : President[] = [
   {
     name: "Myreech Oiaboy",
     party: "whig",
-    birth: d(1824),
-    death: d(1917),
+    birth: d(1824, 10, 27),
+    death: d(1917, 12, 6),
     events: [
-      { date: d(1842), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1853), type: PRESIDENCY_ENDS, text: "Stepped down" },
-      { date: d(1917), type: DEATH, text: "died of stroke" }
+      { date: d(1842, 1, 2), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1853, 1, 14), type: PRESIDENCY_ENDS, text: "Stepped down" },
+      { date: d(1917, 8, 24), type: DEATH, text: "died of stroke" }
     ]
   },
   {
     name: "Tennisonopi Avots",
     party: "conservative",
-    birth: d(1798),
-    death: d(1863),
+    birth: d(1798, 1, 4),
+    death: d(1863, 12, 18),
     events: [
-      { date: d(1853), type: PRESIDENCY_BEGINS, text: "Elected (by retroactive declaration)" },
-      { date: d(1863), type: PRESIDENCY_ENDS, text: "died of stroke" }
+      { date: d(1853, 9, 26), type: PRESIDENCY_BEGINS, text: "Elected (by retroactive declaration)" },
+      { date: d(1863, 10, 21), type: PRESIDENCY_ENDS, text: "died of stroke" }
     ]
   },
   {
     name: "Spindle Gowlash",
     party: "radical",
-    birth: d(1839),
-    death: d(1910),
+    birth: d(1839, 3, 17),
+    death: d(1910, 3, 3),
     events: [
-      { date: d(1863), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1867), type: PRESIDENCY_ENDS, text: "resigned" },
-      { date: d(1910), type: DEATH, text: "died of flu" }
+      { date: d(1863, 1, 24), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1867, 4, 17), type: PRESIDENCY_ENDS, text: "resigned" },
+      { date: d(1910, 5, 16), type: DEATH, text: "died of flu" }
     ]
   },
 
 {
     name: "flint vapourmark",
     party: "radical",
-    birth: d(1815),
-    death: d(1872),
+    birth: d(1815, 2, 18),
+    death: d(1872, 3, 18),
     events: [
-      { date: d(1867), type: PRESIDENCY_BEGINS, text: "" },
-      { date: d(1869), type: PRESIDENCY_ENDS, text: "lost re election" },
-      { date: d(1872), type: DEATH, text: "gangreene" }
+      { date: d(1867, 2, 24), type: PRESIDENCY_BEGINS, text: "" },
+      { date: d(1869, 5, 14), type: PRESIDENCY_ENDS, text: "lost re election" },
+      { date: d(1872, 12, 24), type: DEATH, text: "gangreene" }
     ]
   },
 
   {
     name: "davi rovfe",
     party: "conservative",
-    birth: d(1840),
-    death: d(1926),
+    birth: d(1840, 3, 15),
+    death: d(1926, 8, 24),
     events: [
-      { date: d(1869), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1889), type: PRESIDENCY_ENDS, text: "Resigned due to illness" },
-      { date: d(1926), type: DEATH, text: "died of scurvy" }
+      { date: d(1869, 8, 24), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1889, 11, 13), type: PRESIDENCY_ENDS, text: "Resigned due to illness" },
+      { date: d(1926, 11, 5), type: DEATH, text: "died of scurvy" }
     ]
   },
 
   {
     name: "ben joinse",
     party: "whig",
-    birth: d(1859),
-    death: d(1948),
+    birth: d(1859, 3, 22),
+    death: d(1948, 9, 14),
     events: [
-      { date: d(1889), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1897), type: PRESIDENCY_ENDS, text: "lost re election" },
-      { date: d(1948), type: DEATH, text: "died of dropsy" }
+      { date: d(1889, 2, 12), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1897, 1, 10), type: PRESIDENCY_ENDS, text: "lost re election" },
+      { date: d(1948, 7, 14), type: DEATH, text: "died of dropsy" }
     ]
   },
   
   {
     name: "myrecce beeryhorn",
     party: "radical",
-    birth: d(1857),
-    death: d(1915),
+    birth: d(1857, 1, 2),
+    death: d(1915, 2, 23),
     events: [
-      { date: d(1897), type: PRESIDENCY_BEGINS, text: "elected" },
-      { date: d(1899), type: PRESIDENCY_ENDS, text: "lost re election"},
-      { date: d(1915), type: DEATH, text: "tooth infection" }
+      { date: d(1897, 5, 18), type: PRESIDENCY_BEGINS, text: "elected" },
+      { date: d(1899, 8, 8), type: PRESIDENCY_ENDS, text: "lost re election"},
+      { date: d(1915, 3, 10), type: DEATH, text: "tooth infection" }
     ]
   },
 
@@ -331,153 +331,153 @@ export const PRESIDENTS : President[] = [
   {
     name: "lila file",
     party: "independent",
-    birth: d(1867),
-    death: d(1957),
+    birth: d(1867, 4, 25),
+    death: d(1957, 6, 17),
     events: [
-      { date: d(1899), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1910), type: PRESIDENCY_ENDS, text: "Retired" },
-      { date: d(1957), type: DEATH, text: "died of carrotaminia" }
+      { date: d(1899, 3, 11), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1910, 10, 4), type: PRESIDENCY_ENDS, text: "Retired" },
+      { date: d(1957, 8, 11), type: DEATH, text: "died of carrotaminia" }
     ]
   },
   {
     name: "Anamalo Synth",
     party: "labour",
-    birth: d(1871),
-    death: d(1959),
+    birth: d(1871, 4, 2),
+    death: d(1959, 10, 13),
     events: [
-      { date: d(1910), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1920), type: PRESIDENCY_ENDS, text: "Resigned" },
-      { date: d(1959), type: DEATH, text: "died of stroke" }
+      { date: d(1910, 9, 28), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1920, 3, 3), type: PRESIDENCY_ENDS, text: "Resigned" },
+      { date: d(1959, 2, 17), type: DEATH, text: "died of stroke" }
     ]
   },
   {
     name: "Rob Reddik",
     party: "conservative",
-    birth: d(1863),
-    death: d(1930),
+    birth: d(1863, 7, 6),
+    death: d(1930, 9, 16),
     events: [
-      { date: d(1920), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1929), type: PRESIDENCY_ENDS, text: "Lost re-election" },
-      { date: d(1930), type: DEATH, text: "died of kidney failure" }
+      { date: d(1920, 6, 25), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1929, 5, 7), type: PRESIDENCY_ENDS, text: "Lost re-election" },
+      { date: d(1930, 10, 15), type: DEATH, text: "died of kidney failure" }
     ]
   },    
   {
     name: "Avae Romrowabala",
     party: 'whig',
-    birth: d(1887),
-    death: d(1970),
+    birth: d(1887, 11, 27),
+    death: d(1970, 11, 3),
     events: [
-      { date: d(1929), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1947), type: PRESIDENCY_ENDS, text: "Kicked out" },
-      { date: d(1948), type: PRESIDENCY_BEGINS, text: "Resumed office" },
-      { date: d(1954), type: PRESIDENCY_ENDS, text: "Retired" },
-      { date: d(1970), type: DEATH, text: "died of stomach cancer" }
+      { date: d(1929, 7, 18), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1947, 11, 7), type: PRESIDENCY_ENDS, text: "Kicked out" },
+      { date: d(1948, 7, 11), type: PRESIDENCY_BEGINS, text: "Resumed office" },
+      { date: d(1954, 5, 20), type: PRESIDENCY_ENDS, text: "Retired" },
+      { date: d(1970, 2, 8), type: DEATH, text: "died of stomach cancer" }
     ]
   },
   {
     name: "Edwin Peake",
-    birth: d(1904),
+    birth: d(1904, 11, 12),
     party: "conservative",
-    death: d(1992),
+    death: d(1992, 8, 10),
     events: [
-      { date: d(1947), type: PRESIDENCY_BEGINS, text: "Seized power" },
-      { date: d(1948), type: PRESIDENCY_ENDS, text: "Overthrown" },
-      { date: d(1992), type: DEATH, text: "died of parkinson's disease" }
+      { date: d(1947, 3, 15), type: PRESIDENCY_BEGINS, text: "Seized power" },
+      { date: d(1948, 3, 17), type: PRESIDENCY_ENDS, text: "Overthrown" },
+      { date: d(1992, 6, 9), type: DEATH, text: "died of parkinson's disease" }
     ]
   },  
   {
     name: "Alec Oven",
     party: "DONEX",
-    birth: d(1924),
-    death: d(1980),
+    birth: d(1924, 3, 5),
+    death: d(1980, 3, 24),
     events: [
-      { date: d(1954), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1957), type: PRESIDENCY_ENDS, text: "Term ended" },
-      { date: d(1980), type: DEATH, text: "died of  throat cancer and stabbed by servant" }
+      { date: d(1954, 7, 26), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1957, 11, 25), type: PRESIDENCY_ENDS, text: "Term ended" },
+      { date: d(1980, 12, 22), type: DEATH, text: "died of  throat cancer and stabbed by servant" }
     ]
   },
  {
     name: "featerry joilpb",
     party: "labour",
-    birth: d(1910),
-    death: d(2000),
+    birth: d(1910, 9, 13),
+    death: d(2000, 8, 26),
     events: [
-      { date: d(1957), type: PRESIDENCY_BEGINS, text: "elected" },
-      { date: d(1961), type: PRESIDENCY_ENDS, text: "resigned" },
-      { date: d(2000), type: DEATH, text: "died of TB" }
+      { date: d(1957, 4, 8), type: PRESIDENCY_BEGINS, text: "elected" },
+      { date: d(1961, 2, 27), type: PRESIDENCY_ENDS, text: "resigned" },
+      { date: d(2000, 6, 4), type: DEATH, text: "died of TB" }
     ]
   },
   {
     name: "Avia Gow",
-    birth: d(1933),
+    birth: d(1933, 11, 26),
     party: "liberal democratic",
     death: null,
     events: [
-      { date: d(1961), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1965), type: PRESIDENCY_ENDS, text: "Term ended" },
+      { date: d(1961, 10, 16), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1965, 10, 5), type: PRESIDENCY_ENDS, text: "Term ended" },
     ]
   },  
   {
     name: "Ajaxio Collad",
     party:"snackalist",
-    birth: d(1915),
-    death: d(2007),
+    birth: d(1915, 7, 23),
+    death: d(2007, 8, 5),
     events: [
-      { date: d(1965), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1967), type: PRESIDENCY_ENDS, text: "Lost re-election" },
-      { date: d(2007), type: DEATH, text: "died of heart attack" }
+      { date: d(1965, 1, 7), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1967, 9, 27), type: PRESIDENCY_ENDS, text: "Lost re-election" },
+      { date: d(2007, 10, 23), type: DEATH, text: "died of heart attack" }
     ]
   },
   {
     name: "shorn oatly",
     party: "labour",
-    birth: d(1920),
-    death: d(2014),
+    birth: d(1920, 4, 12),
+    death: d(2014, 12, 21),
     events: [
-      { date: d(1967), type: PRESIDENCY_BEGINS, text: "elected" },
-      { date: d(1970), type: PRESIDENCY_ENDS, text: "lost re election" },
-      { date: d(2014), type: DEATH, text: "died of heart failure" }
+      { date: d(1967, 1, 16), type: PRESIDENCY_BEGINS, text: "elected" },
+      { date: d(1970, 6, 23), type: PRESIDENCY_ENDS, text: "lost re election" },
+      { date: d(2014, 11, 5), type: DEATH, text: "died of heart failure" }
     ]
   },  
   {
     name: "Ajaysoionvasao Foallowa",
-    birth: d(1931),
+    birth: d(1931, 6, 10),
     party:"labour",
     death: null,
     events: [
-      { date: d(1970), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1981), type: PRESIDENCY_ENDS, text: "Term ended" },
+      { date: d(1970, 2, 19), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1981, 6, 4), type: PRESIDENCY_ENDS, text: "Term ended" },
     ]
   },
   {
     name: "Herbert Lovvbert",
-    birth: d(1951),
+    birth: d(1951, 11, 15),
     party:"labour",
     death: null,
     events: [
-      { date: d(1981), type:PRESIDENCY_BEGINS, text: "Elected 1981 but for a few days only" },
-      { date: d(1981), type:PRESIDENCY_ENDS, text: "Elected 1981 but for a few days only" },
-      { date: d(1988), type:PRESIDENCY_BEGINS, text: "Re-elected" },
-      { date: d(2023), type:PRESIDENCY_ENDS, text: "Retired" }
+      { date: d(1981, 1, 2), type:PRESIDENCY_BEGINS, text: "Elected 1981 but for a few days only" },
+      { date: d(1981, 6, 1), type:PRESIDENCY_ENDS, text: "Elected 1981 but for a few days only" },
+      { date: d(1988, 7, 1), type:PRESIDENCY_BEGINS, text: "Re-elected" },
+      { date: d(2023, 3, 15), type:PRESIDENCY_ENDS, text: "Retired" }
     ]
   },
   {
     name: "Effesi Collad",
-    birth: d(1950),
+    birth: d(1950, 4, 6),
     party:"snackalist",
     death: null,
     events: [
-      { date: d(1981), type: PRESIDENCY_BEGINS, text: "Elected" },
-      { date: d(1988), type: PRESIDENCY_ENDS, text: "Lost election" },
+      { date: d(1981, 3, 10), type: PRESIDENCY_BEGINS, text: "Elected" },
+      { date: d(1988, 10, 8), type: PRESIDENCY_ENDS, text: "Lost election" },
     ]
   },  
   {
     name: "Baahram Linco",
     party: "whig",
-    birth: d(1979),
+    birth: d(1979, 9, 24),
     death: null,
     events: [
-      { date: d(2023), type: PRESIDENCY_BEGINS, text: "Elected" }
+      { date: d(2023, 10, 24), type: PRESIDENCY_BEGINS, text: "Elected" }
     ]
   }
 ];
@@ -485,103 +485,103 @@ export const PRESIDENTS : President[] = [
 export const MONARCHS: Monarch[] = [
   {
     name: "high crust",
-    birth: d(1635),
-    death: d(1683),
-    start_reign: d(1656),
-    end_reign: d(1683),
+    birth: d(1635, 11, 21),
+    death: d(1683, 5, 27),
+    start_reign: d(1656, 12, 1),
+    end_reign: d(1683, 3, 2),
     death_cause: "starved to death",
   },
   {
     name: "chumble vainbatter",
-    birth: d(1636),
-    death: d(1701),
-    start_reign: d(1683),
-    end_reign: d(1701),
+    birth: d(1636, 11, 3),
+    death: d(1701, 11, 15),
+    start_reign: d(1683, 1, 24),
+    end_reign: d(1701, 10, 5),
     death_cause: "quatering",
   },  
   {
     name: "benadict I",
-    birth: d(1696),
-    death: d(1759),
-    start_reign: d(1701),
-    end_reign: d(1759),
+    birth: d(1696, 7, 5),
+    death: d(1759, 12, 28),
+    start_reign: d(1701, 4, 7),
+    end_reign: d(1759, 4, 13),
     death_cause: "respetory infection",
   },
   {
     name: "constantine",
-    birth: d(1720),
-    death: d(1793),
-    start_reign: d(1759),
-    end_reign: d(1793),
+    birth: d(1720, 12, 7),
+    death: d(1793, 9, 12),
+    start_reign: d(1759, 8, 25),
+    end_reign: d(1793, 2, 8),
     death_cause: "stroke",
   },
   {
     name: "henry I",
-    birth: d(1745),
-    death: d(1796),
-    start_reign: d(1793),
-    end_reign: d(1796),
+    birth: d(1745, 1, 10),
+    death: d(1796, 12, 13),
+    start_reign: d(1793, 5, 16),
+    end_reign: d(1796, 5, 12),
     death_cause: "shot 3 times by army",
   },
   {
     name: "henry II",
-    birth: d(1763),
-    death: d(1827),
-    start_reign: d(1796),
-    end_reign: d(1827),
+    birth: d(1763, 2, 5),
+    death: d(1827, 10, 27),
+    start_reign: d(1796, 11, 23),
+    end_reign: d(1827, 8, 17),
     death_cause: "pancreatic cancer",
   },
   {
     name: "isabella I",
-    birth: d(1801),
-    death: d(1899),
-    start_reign: d(1827),
-    end_reign: d(1899),
+    birth: d(1801, 8, 3),
+    death: d(1899, 8, 27),
+    start_reign: d(1827, 1, 11),
+    end_reign: d(1899, 2, 24),
     death_cause: "toncil failure",
   },
   {
     name: "henry III",
-    birth: d(1832),
-    death: d(1907),
-    start_reign: d(1899),
-    end_reign: d(1907),
+    birth: d(1832, 8, 5),
+    death: d(1907, 9, 15),
+    start_reign: d(1899, 2, 16),
+    end_reign: d(1907, 9, 1),
     death_cause: "lucemia",
   },
 
     {
     name: "leopold I",
-    birth: d(1858),
-    death: d(1937),
-    start_reign: d(1907),
-    end_reign: d(1937),
+    birth: d(1858, 6, 23),
+    death: d(1937, 9, 14),
+    start_reign: d(1907, 9, 27),
+    end_reign: d(1937, 4, 9),
     death_cause: "heart attack",
   },   
 
 
     {
     name: "leopold II",
-    birth: d(1900),
-    death: d(1981),
-    start_reign: d(1837),
-    end_reign: d(1981),
+    birth: d(1900, 9, 24),
+    death: d(1981, 3, 13),
+    start_reign: d(1837, 12, 2),
+    end_reign: d(1981, 2, 8),
     death_cause: "heart failure",
   },   
 
 
     {
     name: "isabella II",
-    birth: d(1927),
-    death: d(2024),
-    start_reign: d(1981),
-    end_reign: d(2024),
+    birth: d(1927, 4, 25),
+    death: d(2024, 6, 4),
+    start_reign: d(1981, 3, 13),
+    end_reign: d(2024, 11, 2),
     death_cause: "heart deisese",
   },   
   
   {
     name: "leopold II",
-    birth: d(1960),
+    birth: d(1960, 5, 3),
     death: null,
-    start_reign: d(2024),
+    start_reign: d(2024, 9, 9),
     end_reign: null,
     death_cause: null
   }


### PR DESCRIPTION
## Summary
- add diverse month/day values to all presidential events and biography dates to remove Jan 1 defaults

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6821069708326b0d552de4e1ab63c