### PR TITLE
Add country selector and Nitopia timeline

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -174,3 +174,31 @@ button:hover {
 .volume-control {
   margin: 5px;
 }
+
+.controls-row {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 15px;
+}
+
+.controls-row label {
+  font-weight: bold;
+  font-size: 0.9rem;
+}
+
+select {
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: white;
+  padding: 6px 12px;
+  border-radius: 12px;
+  font-size: 0.9rem;
+}
+
+select:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(0, 212, 255, 0.5);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,8 +3,8 @@ import type { Metadata } from 'next';
 import { ReactNode } from 'react';
 
 export const metadata: Metadata = {
-  title: 'Aerobea Presidential Timeline',
-  description: 'Timeline of Aerobea Presidents',
+  title: 'Fictional Presidential Timelines',
+  description: 'Explore the leadership histories of Aerobea, Nitopia, and beyond.',
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/components/TimelineGrid.tsx
+++ b/components/TimelineGrid.tsx
@@ -15,6 +15,8 @@ const PARTY_COLOURS: Record<string, string> = {
   'radical': '#0b3e16ff',
   'feather first': '#000000ff',
   'snackalist': '#c15c22ff',
+  'ghanaio party': '#1f6f50',
+  'organisational conservative party': '#1f3d7a',
 };
 
 interface TimelineGridProps {

--- a/data/countries.ts
+++ b/data/countries.ts
@@ -1,0 +1,133 @@
+import {
+  d,
+  START,
+  END,
+  PRESIDENTS,
+  MONARCHS,
+  President,
+  Monarch,
+  PRESIDENCY_BEGINS,
+  PRESIDENCY_ENDS,
+  DEATH,
+} from './presidents';
+
+export interface CountryTimeline {
+  code: string;
+  name: string;
+  start: Date;
+  end: Date;
+  presidents: President[];
+  monarchs: Monarch[];
+}
+
+const NITOPIA_START = d(1801, 1, 1);
+const NITOPIA_END = d(2004, 12, 31);
+
+const NITOPIA_PRESIDENTS: President[] = [
+  {
+    name: 'Bertram Woolcrest',
+    party: 'Ghanaio Party',
+    birth: d(1801, 2, 14),
+    death: d(1875, 10, 6),
+    events: [
+      {
+        date: d(1843, 5, 11),
+        type: PRESIDENCY_BEGINS,
+        text: 'First president of the Nitopian Republic',
+      },
+      {
+        date: d(1851, 12, 3),
+        type: PRESIDENCY_ENDS,
+        text: 'Retired from office',
+      },
+      {
+        date: d(1875, 10, 6),
+        type: DEATH,
+        text: 'Died aged 74 of Deep Scroll Mecholisa cancer',
+      },
+    ],
+  },
+  {
+    name: 'James Jones Loo Moo',
+    party: 'Organisational Conservative Party',
+    birth: d(1921, 7, 9),
+    death: d(2004, 8, 18),
+    events: [
+      {
+        date: d(1975, 4, 29),
+        type: PRESIDENCY_BEGINS,
+        text: 'Caretaker president during instability',
+      },
+      {
+        date: d(1976, 1, 22),
+        type: PRESIDENCY_ENDS,
+        text: 'Stepped down',
+      },
+      {
+        date: d(2004, 8, 18),
+        type: DEATH,
+        text: 'Died aged 83 of heatstroke',
+      },
+    ],
+  },
+];
+
+const NITOPIA_MONARCHS: Monarch[] = [
+  {
+    name: 'Regent Solenne Thry',
+    birth: d(1770, 4, 2),
+    death: d(1848, 6, 19),
+    start_reign: d(1798, 11, 1),
+    end_reign: d(1848, 6, 19),
+    death_cause: 'Complications of silver lung fever',
+  },
+  {
+    name: 'Crown Marshal Dagan Pell',
+    birth: d(1815, 8, 23),
+    death: d(1892, 2, 17),
+    start_reign: d(1848, 6, 19),
+    end_reign: d(1892, 2, 17),
+    death_cause: 'Sky barge collision over the violet marshes',
+  },
+  {
+    name: 'Speaker Imara Quell',
+    birth: d(1860, 1, 14),
+    death: d(1972, 9, 30),
+    start_reign: d(1892, 2, 17),
+    end_reign: d(1972, 9, 30),
+    death_cause: 'Quiet fade illness',
+  },
+  {
+    name: 'Crown Mediator Halevi Morcant',
+    birth: d(1938, 12, 5),
+    death: null,
+    start_reign: d(1972, 10, 1),
+    end_reign: null,
+    death_cause: null,
+  },
+];
+
+export const COUNTRIES: CountryTimeline[] = [
+  {
+    code: 'aerobea',
+    name: 'Aerobea',
+    start: START,
+    end: END,
+    presidents: PRESIDENTS,
+    monarchs: MONARCHS,
+  },
+  {
+    code: 'nitopia',
+    name: 'Nitopia',
+    start: NITOPIA_START,
+    end: NITOPIA_END,
+    presidents: NITOPIA_PRESIDENTS,
+    monarchs: NITOPIA_MONARCHS,
+  },
+];
+
+export const DEFAULT_COUNTRY_CODE = 'aerobea';
+
+export function getCountryByCode(code: string): CountryTimeline | undefined {
+  return COUNTRIES.find(country => country.code === code);
+}

--- a/data/presidents.ts
+++ b/data/presidents.ts
@@ -1,4 +1,4 @@
-const d = (y: number, m = 1, day = 1) => new Date(Date.UTC(y, m - 1, day));
+export const d = (y: number, m = 1, day = 1) => new Date(Date.UTC(y, m - 1, day));
 export const START = d(1672, 1, 1);
 export const END = d(2025, 12, 31);
 export const PRESIDENCY_BEGINS = 1;


### PR DESCRIPTION
## Summary
- create a shared country data module and add Nitopia's presidents and monarchs
- update the main page to select timelines by country, including a generated timeline state and dropdown styling
- adjust styling, metadata, and party colour mappings to support the expanded dataset

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ce56d622cc83269299f4f01e1ff57e